### PR TITLE
Use default locale instead of hard-coded value

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -16,7 +16,7 @@ framework:
     templating:
         engines: ['twig']
         #assets_version: SomeVersionScheme
-    default_locale:  de #"%locale%"
+    default_locale:  "%locale%"
     trusted_hosts:   ~
     trusted_proxies: ~
     session:


### PR DESCRIPTION
Changed framework.default_locale config to "%locale%", so the demo uses the locale in parameters.yml, that is actually setted when 'composer install' is performed.